### PR TITLE
Change alpha attributes type to float

### DIFF
--- a/simplesearchview/src/main/res/values/attrs.xml
+++ b/simplesearchview/src/main/res/values/attrs.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="SimpleSearchView">
-        <attr name="backIconAlpha" format="dimension" />
-        <attr name="iconsAlpha" format="dimension" />
+        <attr name="backIconAlpha" format="float" />
+        <attr name="iconsAlpha" format="float" />
 
         <attr name="backIconTint" format="color" />
         <attr name="iconsTint" format="color" />


### PR DESCRIPTION
These attributes should be of `float` type, since this type is used in Java code: https://github.com/Ferfalk/SimpleSearchView/blob/master/simplesearchview/src/main/java/com/ferfalk/simplesearchview/SimpleSearchView.java#L144

Float is more suitable for alpha values than `dimension`.